### PR TITLE
Add `safe` to url outputs

### DIFF
--- a/templates/categories/list.html
+++ b/templates/categories/list.html
@@ -11,7 +11,7 @@
         <ul>
             {% for term in terms %}
                 <li>
-                    <a href="{{ term.permalink }}">{{ term.name }}</a>({{ term.pages | length }})
+                    <a href="{{ term.permalink | safe }}">{{ term.name }}</a>({{ term.pages | length }})
                 </li>
             {% endfor %}
         </ul>

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,11 +12,11 @@
       <title>{% block title %}{{ config.title }}{% endblock title %}</title>
 
       {% if config.generate_rss %}
-        <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path="rss.xml") }}">
+        <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path="rss.xml") | safe }}">
       {% endif %}
 
       {% block css %}
-          <link rel="stylesheet" href="{{ get_url(path="site.css", trailing_slash=false) }}">
+          <link rel="stylesheet" href="{{ get_url(path="site.css", trailing_slash=false) | safe }}">
       {% endblock css %}
 
       {% block extra_head %}
@@ -32,7 +32,7 @@
                         {% for item in config.extra.after_dark_menu %}
                             <a itemprop="url"
                                class="{% if item.url | replace(from="$BASE_URL", to=config.base_url) == current_url %}active{% endif %}"
-                               href="{{ item.url | replace(from="$BASE_URL", to=config.base_url) }}">
+                               href="{{ item.url | safe | replace(from="$BASE_URL", to=config.base_url) }}">
                                 <span itemprop="name">{{ item.name }}
                                 </span></a>
                         {% endfor %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -21,12 +21,12 @@
                 {% endif %}
                 {% if page.taxonomies.categories %}
                     {% set category = page.taxonomies.categories[0] %}
-                    in <a href="{{ get_taxonomy_url(kind="categories", name=category) }}">{{ category }}</a>
+                    in <a href="{{ get_taxonomy_url(kind="categories", name=category) | safe }}">{{ category }}</a>
                 {% endif %}
                 {% if page.taxonomies.tags %}
                     and tagged
                     {% for tag in page.taxonomies.tags %}
-                        <a href="{{ get_taxonomy_url(kind="tags", name=tag) }}">{{ tag }}</a>
+                        <a href="{{ get_taxonomy_url(kind="tags", name=tag) | safe }}">{{ tag }}</a>
                         {% if page.taxonomies.tags | length > 1 %}
                             {% if loop.index != page.taxonomies.tags | length %}
                                 {% if loop.index == page.taxonomies.tags | length - 1 %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -3,6 +3,22 @@
 
 {% block content %}
 
+    {% block header %}
+	{% if config.extra.after_dark_menu %}
+	    <header>
+		<nav itemscope itemtype="http://schema.org/SiteNavigationElement">
+		{% for item in config.extra.after_dark_menu %}
+		    <a itemprop="url"
+		       class="{% if item.url | replace(from="$BASE_URL", to=config.base_url) == current_url %}active{% endif %}"
+		       href="{{ item.url | safe | replace(from="$BASE_URL", to=config.base_url) }}">
+			<span itemprop="name">{{ item.name }}
+			</span></a>
+		{% endfor %}
+		</nav>
+	    </header>
+	{% endif %}
+    {% endblock header %}
+
 <article itemscope itemtype="http://schema.org/BlogPosting">
     <header>
         <h1 itemprop="headline">{{ page.title }}</h1>

--- a/templates/post_macros.html
+++ b/templates/post_macros.html
@@ -19,14 +19,14 @@
     <article itemscope itemtype="http://schema.org/CreativeWork">
         <header>
             <h2 itemprop="name">
-                <a href="{{ page.permalink }}">{{ page.title }}</a>
+                <a href="{{ page.permalink | safe }}">{{ page.title }}</a>
             </h2>
             <span class="muted">{{ self::meta(page=page) }}</span>
         </header>
         {% if page.summary %}
             <div itemprop="summary">
                 {{ page.summary | safe }}
-                <nav class="readmore"><a itemprop="url" href="{{ page.permalink }}">Read More&nbsp;&raquo;</a></nav>
+                <nav class="readmore"><a itemprop="url" href="{{ page.permalink | safe }}">Read More&nbsp;&raquo;</a></nav>
             </div>
         {% endif %}
     </article>

--- a/templates/tags/list.html
+++ b/templates/tags/list.html
@@ -10,7 +10,7 @@
     {% if terms %}
         <ul>
             {% for term in terms %}
-                <li><a href="{{ term.permalink }}">{{ term.name }}</a> ({{ term.pages | length }})</li>
+                <li><a href="{{ term.permalink | safe }}">{{ term.name }}</a> ({{ term.pages | length }})</li>
             {% endfor %}
         </ul>
     {% endif %}


### PR DESCRIPTION
I added `safe` to a few splices that were outputting urls. I'm not sure if there's a better way to do this, but this fixed the overly-escaped output for me.