### PR TITLE
Google Lighthouse Accessibility Fix

### DIFF
--- a/sass/_theme.scss
+++ b/sass/_theme.scss
@@ -90,7 +90,7 @@ blockquote cite::before {
 }
 
 nav a.active {
-  background-color: #ff2e88;
+  background-color: #e50074;
   color: #fff;
 }
 

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -1,8 +1,8 @@
 @use "vendor";
 @use "theme";
-@import "parts/note";
-@import "parts/code";
-@import "parts/search";
+@use "parts/note";
+@use "parts/code";
+@use "parts/search";
 
 :root {
   --note-color: #00c6ff;


### PR DESCRIPTION
Google Lighthouse was flagging an accessibility issue from poor contrast on the active link.

I plugged the original color into this site: https://www.learnui.design/tools/accessible-color-generator.html

This gives a visually similar color improving the contrast enough to pass google accessibility, bringing the score to 100.

I also swapped the `@import` from a recent pull request to use `@use` instead.